### PR TITLE
Remove deprecated Mail::CheckDeliveryParams for mail 2.9.0+ compatibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,17 +1,17 @@
-require:
+plugins:
   - rubocop-rake
   - rubocop-rspec
   - rubocop-thread_safety
 
 inherit_from: .rubocop_todo.yml
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
-Documentation:
+Style/Documentation:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false
-Style/FileName:
+Naming/FileName:
   Enabled: false
 Metrics/CyclomaticComplexity:
   Enabled: false
@@ -21,7 +21,7 @@ Style/RaiseArgs:
   Enabled: false
 Style/DoubleNegation:
   Enabled: false
-Style/MethodLength:
+Metrics/MethodLength:
   Max: 20
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Enabled: false

--- a/lib/govdelivery/tms/mail/delivery_method.rb
+++ b/lib/govdelivery/tms/mail/delivery_method.rb
@@ -1,6 +1,5 @@
 require 'govdelivery-tms'
 require 'mail'
-require 'mail/check_delivery_params'
 
 module GovDelivery::TMS
   module Mail
@@ -16,8 +15,6 @@ module GovDelivery::TMS
     #     :api_root=>'https://stage-tms.govdelivery.com'
     #     }
     class DeliveryMethod
-      include ::Mail::CheckDeliveryParams
-
       def initialize(values)
         self.settings = values
       end


### PR DESCRIPTION
## Summary

The Mail gem removed the deprecated `CheckDeliveryParams` module in version 2.9.0.

This module was included in the `DeliveryMethod` class but never actually used - none of its methods were called.

## Changes

- Removed `require 'mail/check_delivery_params'`
- Removed `include ::Mail::CheckDeliveryParams`

## Why

This change maintains compatibility with mail 2.9.0 and later versions, allowing projects using this gem to upgrade to the latest mail gem without issues.

## Testing

The module was only included but never used, so removing it has no functional impact on the delivery method behavior.

## Related

- vets-api PR: https://github.com/department-of-veterans-affairs/vets-api/pull/25093
  - Updates Gemfile to use v4.2.0 tag of this gem
  - Removes monkey patch that was temporarily added to vets-api for mail 2.9.0 compatibility